### PR TITLE
Update hashes on older models

### DIFF
--- a/hunpos/hmm_tagger.ml
+++ b/hunpos/hmm_tagger.ml
@@ -183,7 +183,18 @@ let load file_name =
 	let (m, stat, apriori_tag_probs) = Marshal.from_channel ic in
 	close_in ic;
 	m.apriori_tag_probs <- apriori_tag_probs ;
-	(m, stat)	
+        (* In ocaml v4.00.0 the hashtbl hash function was changed
+        which means that when we read the data from a model file that
+        was made with a version that is older then that the hashes in
+        the vocabulary table are noe longer the same. The following
+        try-with checks for the error and applies the fix if
+        neccessary. *)
+	try
+          Vocab.toword m.tag_vocab 1;
+          (m, stat)
+        with
+          Not_found ->
+          ({m with tag_vocab = (Vocab.fix_old_vocab m.tag_vocab)}, stat)
 
 type seen_type = Seen | LowerCasedSeen | SpecialToken | UnSeen
 

--- a/util/vocab.ml
+++ b/util/vocab.ml
@@ -21,4 +21,12 @@ let ngram_toindex vocab ngram =
 	List.map (toindex vocab) ngram
 	
 let max (_, _, max) = !max
-	
+
+let fix_old_vocab (_, old_id2word, max) =
+  let (word2id, id2word, _) = create () in
+  let add (id, word) =
+    IHash.add_or_replace id2word id word;
+    SHash.add_or_replace word2id word id;
+  in
+   List.map add (IHash.to_list old_id2word);
+   (word2id, id2word, max)

--- a/util/vocab.mli
+++ b/util/vocab.mli
@@ -4,4 +4,4 @@ val toindex : t -> string -> int
 val toword : t -> int -> string
 val ngram_toindex : t-> string list -> int list
 val max : t -> int
-
+val fix_old_vocab : t -> t


### PR DESCRIPTION
- hunpos/hmm_tagger.ml (load): Check if we can find `<s>` in tag_vocab, if
  not we run the fix and return a model with an updated vocabulary.
- util/vocab.ml (fix_old_vocab): New function. Creates a new vocab where
  the ids and word are rehashed.

This fix makes it possible to use old models like [en_wsj.model](https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/hunpos/en_wsj.model.gz) again without having to re-train the model.
